### PR TITLE
Update library to mysql2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A MySQL client for Node.js that makes defining tables easy and automatically migrates table schemas.
 
-This module extends the popular [`mysql`](https://www.npmjs.com/package/mysql) module, so it is recommended that you read the [`mysql` documentation](https://github.com/mysqljs/mysql#introduction), especially the sections on [connection options](https://github.com/mysqljs/mysql#connection-options), [performing queries](https://github.com/mysqljs/mysql#performing-queries), [escaping query values](https://github.com/mysqljs/mysql#escaping-query-values), and [escaping query identifiers](https://github.com/mysqljs/mysql#escaping-query-identifiers).
+This module extends the popular [`mysql2`](https://www.npmjs.com/package/mysql2) module, so it is recommended that you read the [`mysql` documentation](https://github.com/mysqljs/mysql#introduction), especially the sections on [connection options](https://github.com/mysqljs/mysql#connection-options), [performing queries](https://github.com/mysqljs/mysql#performing-queries), [escaping query values](https://github.com/mysqljs/mysql#escaping-query-values), and [escaping query identifiers](https://github.com/mysqljs/mysql#escaping-query-identifiers).
 
 ## Table of Contents
 
@@ -259,7 +259,7 @@ A function called with the results of a query.
 <a name="PoolPlus"></a>
 
 ## PoolPlus ⇐ <code>Pool</code>
-A class that extends the `mysql` module's `Pool` class with the ability to define tables
+A class that extends the `mysql2` module's `Pool` class with the ability to define tables
 and perform queries and transactions using promises.
 
 **Extends**: <code>Pool</code>
@@ -591,7 +591,7 @@ function trxnHandler(trxn, done) {
 <a name="Connection"></a>
 
 ## Connection
-The `mysql` module's `Connection` class extended with one extra method. Returned by
+The `mysql2` module's `Connection` class extended with one extra method. Returned by
   [`mysql.createConnection()`](https://github.com/mysqljs/mysql#establishing-connections)
   and [`pool.getConnection()`](https://github.com/mysqljs/mysql#pooling-connections) and
   passed to [`transactionHandler`](#PoolPlus..transactionHandler).

--- a/jsdoc2md/README.hbs
+++ b/jsdoc2md/README.hbs
@@ -8,7 +8,7 @@
 
 A MySQL client for Node.js that makes defining tables easy and automatically migrates table schemas.
 
-This module extends the popular [`mysql`](https://www.npmjs.com/package/mysql) module, so it is recommended that you read the [`mysql` documentation](https://github.com/mysqljs/mysql#introduction), especially the sections on [connection options](https://github.com/mysqljs/mysql#connection-options), [performing queries](https://github.com/mysqljs/mysql#performing-queries), [escaping query values](https://github.com/mysqljs/mysql#escaping-query-values), and [escaping query identifiers](https://github.com/mysqljs/mysql#escaping-query-identifiers).
+This module extends the popular [`mysql2`](https://www.npmjs.com/package/mysql2) module, so it is recommended that you read the [`mysql` documentation](https://github.com/mysqljs/mysql#introduction), especially the sections on [connection options](https://github.com/mysqljs/mysql#connection-options), [performing queries](https://github.com/mysqljs/mysql#performing-queries), [escaping query values](https://github.com/mysqljs/mysql#escaping-query-values), and [escaping query identifiers](https://github.com/mysqljs/mysql#escaping-query-identifiers).
 
 ## Table of Contents
 

--- a/lib/ColumnDefinitions/ColumnDefinition.js
+++ b/lib/ColumnDefinitions/ColumnDefinition.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const mysql = require('mysql');
+const mysql = require('mysql2');
 
 function escapeDefault(value) {
   if (typeof value === 'boolean') {

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Connection = require('mysql/lib/Connection');
+const {Connection} = require('mysql2');
 
 /**
  * @class Connection

--- a/lib/KeyDefinitions/ForeignKeyDefinition.js
+++ b/lib/KeyDefinitions/ForeignKeyDefinition.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const arraysEqual = require('../utils/arraysEqual');
-const {escapeId} = require('mysql/lib/protocol/SqlString');
+const {escapeId} = require('sqlstring');
 
 const referenceOptions = ['RESTRICT', 'CASCADE', 'SET NULL', 'NO ACTION'];
 

--- a/lib/KeyDefinitions/IndexKeyDefinition.js
+++ b/lib/KeyDefinitions/IndexKeyDefinition.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const arraysEqual = require('../utils/arraysEqual');
-const {escapeId} = require('mysql/lib/protocol/SqlString');
+const {escapeId} = require('sqlstring');
 const parseKeyParts = require('../utils/parseKeyParts');
 
 class IndexKeyDefinition {

--- a/lib/MySQLPlus.js
+++ b/lib/MySQLPlus.js
@@ -4,7 +4,7 @@ const ColumnDefinitions = require('./ColumnDefinitions');
 const KeyDefinitions = require('./KeyDefinitions');
 const PoolPlus = require('./PoolPlus');
 
-const mysql = require('mysql');
+const mysql = require('mysql2');
 
 require('./Connection'); // Extends mysql Connection
 

--- a/lib/PoolPlus.js
+++ b/lib/PoolPlus.js
@@ -7,9 +7,9 @@ const ColumnDefinitions = require('./ColumnDefinitions');
 const KeyDefinitions = require('./KeyDefinitions');
 const MySQLTable = require('./MySQLTable');
 const Operation = require('./Operation');
-const Pool = require('mysql/lib/Pool');
-const PoolConfig = require('mysql/lib/PoolConfig');
-const SqlString = require('mysql/lib/protocol/SqlString');
+const {Pool} = require('mysql2');
+const mysql = require('mysql2');
+const SqlString = require('sqlstring');
 const TableDefinition = require('./TableDefinition');
 
 const MIGRATION_STRATEGIES = [
@@ -44,9 +44,11 @@ function validateMigrationStrategy(strategy) {
 class PoolPlus extends Pool {
   constructor(config) {
     const plusOptions = config.plusOptions || {};
+    delete config.plusOptions;
     validateMigrationStrategy(plusOptions.migrationStrategy);
 
-    super({config: new PoolConfig(config)});
+    const poolConfig = mysql.createPool(config).config;
+    super({config: poolConfig});
 
     this._allowAlterInProduction = plusOptions.allowAlterInProduction || false;
     this._debug = plusOptions.debug || false;

--- a/lib/utils/parseKeyParts.js
+++ b/lib/utils/parseKeyParts.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {escapeId} = require('mysql/lib/protocol/SqlString');
+const {escapeId} = require('sqlstring');
 
 function parseKeyParts(keyParts) {
   const columnNames = [];

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "query"
   ],
   "dependencies": {
-    "mysql": "^2.18.1"
+    "mysql2": "^3.2.0",
+    "sqlstring": "^2.3.3"
   },
   "devDependencies": {
     "@nwoltman/eslint-config": "~0.6.0",
@@ -38,12 +39,12 @@
     "grunt": "^1.0.4",
     "grunt-env": "^1.0.1",
     "grunt-eslint": "^22.0.0",
-    "grunt-jsdoc-to-markdown": "^5.0.0",
+    "grunt-jsdoc-to-markdown": "^6.0.0",
     "grunt-mocha-istanbul": "^5.0.2",
     "grunt-mocha-test": "^0.13.3",
     "istanbul": "^0.4.5",
     "jit-grunt": "^0.10.0",
-    "mocha": "^7.0.1",
+    "mocha": "^10.2.0",
     "semver": "^7.1.3",
     "should": "~13.2.3",
     "should-sinon": "0.0.6",

--- a/tasks/createTestDB.js
+++ b/tasks/createTestDB.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const mysql = require('mysql');
+const mysql = require('mysql2');
 
 module.exports = function(grunt) {
   grunt.registerTask('createTestDB', 'Creates an empty test database', function() {

--- a/test/unit/Connection.test.js
+++ b/test/unit/Connection.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const config = require('../config');
-const mysql = require('mysql');
+const mysql = require('mysql2');
 const sinon = require('sinon');
 
 describe('Connection', () => {

--- a/test/unit/MySQLPlus.test.js
+++ b/test/unit/MySQLPlus.test.js
@@ -5,7 +5,7 @@ const KeyDefinitions = require('../../lib/KeyDefinitions');
 const MySQLPlus = require('../../lib/MySQLPlus');
 const PoolPlus = require('../../lib/PoolPlus');
 
-const mysql = require('mysql');
+const mysql = require('mysql2');
 
 describe('MySQLPlus', () => {
 

--- a/test/unit/PoolPlus.test.js
+++ b/test/unit/PoolPlus.test.js
@@ -3,10 +3,10 @@
 /* eslint-disable no-console, padding-line-between-statements */
 
 const ColumnDefinitions = require('../../lib/ColumnDefinitions');
-const Connection = require('mysql/lib/Connection');
+const {Connection} = require('mysql2');
 const KeyDefinitions = require('../../lib/KeyDefinitions');
 const MySQLTable = require('../../lib/MySQLTable');
-const Pool = require('mysql/lib/Pool');
+const {Pool} = require('mysql2');
 const PoolPlus = require('../../lib/PoolPlus');
 const TableDefinition = require('../../lib/TableDefinition');
 
@@ -570,7 +570,6 @@ describe('PoolPlus', () => {
   describe('when defining tables', () => {
 
     var PoolStub;
-    var PoolConfigStub;
     var MySQLTableStub;
 
     var MockPool;
@@ -582,8 +581,8 @@ describe('PoolPlus', () => {
 
       // Stub some classes
       class MockClass {}
-      PoolStub = sinon.stub(require.cache[require.resolve('mysql/lib/Pool')], 'exports').value(MockClass);
-      PoolConfigStub = sinon.stub(require.cache[require.resolve('mysql/lib/PoolConfig')], 'exports').value(MockClass);
+      const mockFunction = options => options;
+      PoolStub = sinon.stub(require.cache[require.resolve('mysql2')], 'exports').value({Pool: MockClass, createPool: mockFunction});
       MySQLTableStub = sinon.stub(require.cache[require.resolve('../../lib/MySQLTable')], 'exports').value(MockClass);
       sinon.stub(require.cache[require.resolve('../../lib/TableDefinition')], 'exports');
 
@@ -601,7 +600,6 @@ describe('PoolPlus', () => {
     after(() => {
       // Restore stubs
       PoolStub.restore();
-      PoolConfigStub.restore();
       MySQLTableStub.restore();
       require.cache[require.resolve('../../lib/TableDefinition')].exports.restore();
       Map.prototype.has.restore();


### PR DESCRIPTION
`Error: ER_NOT_SUPPORTED_AUTH_MODE: Client does not support authentication protocol requested by server; consider upgrading MySQL client`

The original [mysql](https://www.npmjs.com/package/mysql) library is outdated (last update 3 years ago) and it doesn't support modern MySQL servers. This change updates the library to use [mysql2](https://www.npmjs.com/package/mysql2).

Also - thanks for building this library!